### PR TITLE
fix: update redirect from /changelog to /updates page

### DIFF
--- a/src/components/blog/blog-layout-hero.tsx
+++ b/src/components/blog/blog-layout-hero.tsx
@@ -64,7 +64,7 @@ export default function BlogLayoutHero() {
             ))}
             <CategoryLink
               title="Updates"
-              href="/changelog"
+              href="/updates"
               mobile
               setOpenPopover={setOpenPopover}
             />


### PR DESCRIPTION
## Description

This PR fixes the incorrect redirect from Updates page to /changelog by updating it to correctly redirect to /updates page.

## What type of PR is this? (check all applicable)

- [ ] 💡 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [X] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Tickets & Documents

Fixes #20 


## Mobile & Desktop Screenshots/Recordings

![image](https://github.com/user-attachments/assets/10129d56-1c68-4384-af82-8036af8af6ef)

## Steps to QA

1. Click on "Updates" in the navigation
2. Verify you're redirected to /updates path
3. Verify the Updates page loads correctly
4. Check browser console for any redirect-related errors
5. Verify behavior in different browsers (Chrome, Safari)

## Added to documentation?

- [ ] 📜 README.md
- [X] 🙅 no documentation needed

## [optional] Are there any post-deployment tasks we need to perform?

## [optional] What gif best describes this PR or how it makes you feel?

<!-- note: PRs with deleted sections will be marked invalid -->

<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

  For a timely review/response, please avoid force-pushing additional
  commits if your PR already received reviews or comments.

  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->
