### PR TITLE
fix: Floating Action Panel buttons hover state

### DIFF
--- a/src/components/prismui/floating-action-panel.tsx
+++ b/src/components/prismui/floating-action-panel.tsx
@@ -243,7 +243,6 @@ const FloatingActionPanelButton = React.forwardRef<
         className
       )}
       onClick={onClick}
-      whileHover={{ backgroundColor: "rgba(0, 0, 0, 0.05)" }}
       whileTap={{ scale: 0.98 }}
     >
       {children}


### PR DESCRIPTION
# This PR fixes hover state issue in Floating Action Panel component

## While testing the floating action panel on the main Prism UI page, I noticed that the background color of buttons didn’t revert after hovering over it. So I found where the issue was and quickly fixed it.

## What type of PR is this? (check all applicable)

- [ ] 💡 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [x] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Mobile & Desktop Screenshots/Recordings

https://github.com/user-attachments/assets/c6ef8299-3158-458c-87df-56dd4917539b

## Steps to QA
1. Go to the Floating Action Panel and click the button
2. Hover through the items

## Added to documentation?

- [ ] 📜 README.md
- [x] 🙅 no documentation needed