### PR TITLE
Fix:Cards are Misaligned in the GitHub Statistics Section #30

### DIFF
--- a/src/components/sections/repo-activity-client.tsx
+++ b/src/components/sections/repo-activity-client.tsx
@@ -41,7 +41,7 @@ function ActivityCard({
             </h3>
             <div className="flex items-baseline gap-2">
               <span className="text-2xl font-bold">{value}</span>
-              <span className="text-sm text-muted-foreground">
+              <span className="text-sm text-muted-foreground sm:text-nowrap sm:line-clamp-none line-clamp-1">
                 {description}
               </span>
             </div>


### PR DESCRIPTION
Resolved the issue where the cards in the GitHub Statistics section were misaligned, ensuring consistent and responsive layout. This fix improves the user experience by properly aligning the cards across different screen sizes.

## Description

## What type of PR is this? (check all applicable)
- [✔ ] 🐛 Bug Fix

FIx : Cards are Misaligned in the GitHub Statistics Section #30

