### PR TITLE
Fix #47 Navigation Button in Navbar to Redirect to First Component at config.tsx 

### DIFF
--- a/src/lib/config.tsx
+++ b/src/lib/config.tsx
@@ -18,7 +18,7 @@ export const siteConfig = {
       label: "Docs",
     },
     {
-      href: "/docs/",
+      href: "/docs/components/expandable-card",
       label: "Components",
     },
     {


### PR DESCRIPTION
This pull request resolves an issue where the navigation button in the navbar was incorrectly redirecting users to the "Docs" page.

##Bug Fix: Updated the navigation logic to ensure the button now correctly redirects to the first component.
Tested: Verified functionality and navigation path for the button in various scenarios.

##Changes Made
Modified the navigation logic in the Navbar component.
Ensured proper routing to the first component.

##Testing Details
Tested across different environments to confirm correct redirection behavior.
No other components were affected by this change.

#bug 
[screen-capture.webm](https://github.com/user-attachments/assets/096329a4-2e07-48b4-b652-10cf74fbb20a)


#Fixed
![image](https://github.com/user-attachments/assets/fd056a0a-f5a4-493c-a980-700d912f3eb3)
